### PR TITLE
Fix syntax error in the output of for statement with some form of expressions

### DIFF
--- a/src/slimit/tests/test_ecmavisitor.py
+++ b/src/slimit/tests/test_ecmavisitor.py
@@ -119,6 +119,30 @@ class ECMAVisitorTestCase(unittest.TestCase):
 
         }
         """,
+        # retain the semicolon in the initialiser part of a 'for' statement
+        """
+        for (Q || (Q = []); d < b; ) {
+          d = 1;
+        }
+        """,
+
+        """
+        for (new Foo(); d < b; ) {
+          d = 1;
+        }
+        """,
+
+        """
+        for (2 >> (foo ? 32 : 43) && 54; 21; ) {
+          a = c;
+        }
+        """,
+
+        """
+        for (/^.+/g; cond(); ++z) {
+          ev();
+        }
+        """,
 
         # test 12
         """

--- a/src/slimit/visitors/ecmavisitor.py
+++ b/src/slimit/visitors/ecmavisitor.py
@@ -138,7 +138,8 @@ class ECMAVisitor(object):
         if node.init is None:
             s += ' ; '
         elif isinstance(node.init, (ast.Assign, ast.Comma, ast.FunctionCall,
-                                    ast.UnaryOp, ast.Identifier)):
+                                    ast.UnaryOp, ast.Identifier, ast.BinOp,
+                                    ast.Conditional, ast.Regex, ast.NewExpr)):
             s += '; '
         else:
             s += ' '


### PR DESCRIPTION
The semi-colon in the initialiser part of the following for statements
were missing in the .to_ecma() output :

for(Q||(Q=[]);d<b;){d=1;}
for( 2 >> (foo ? 32 : 43) && 54;21;){ a = c;}
for(/^.+/g;cond();++z){ev();}
for((new Number("32"));f;g){}

Fixed by looking for the various AST classes so as to add a
semi-colon or not. Tests added.
