### PR TITLE
Fixed issue #47 where objects with special characters would cause breakage

### DIFF
--- a/src/slimit/visitors/minvisitor.py
+++ b/src/slimit/visitors/minvisitor.py
@@ -34,6 +34,7 @@ _HAS_ID_MATCH = re.compile('^%s$' % Lexer.identifier).match
 def _is_identifier(value):
     return _HAS_ID_MATCH(value) and value not in Lexer.keywords_dict
 
+specials = re.compile(r'[`\\~!@#%\^&*(){}\[\]\-+=/|<>,.:;?]+')
 
 class ECMAMinifier(object):
 
@@ -394,14 +395,15 @@ class ECMAMinifier(object):
     def visit_BracketAccessor(self, node):
         if isinstance(node.expr, ast.String):
             value = node.expr.value
-            # remove single or double quotes around the value, but not both
-            if value.startswith("'"):
-                value = value.strip("'")
-            elif value.startswith('"'):
-                value = value.strip('"')
-            if _is_identifier(value):
-                s = '%s.%s' % (self.visit(node.node), value)
-                return s
+            if not specials.search(value):
+                # remove single or double quotes around the value, but not both
+                if value.startswith("'"):
+                    value = value.strip("'")
+                elif value.startswith('"'):
+                    value = value.strip('"')
+                if _is_identifier(value):
+                    s = '%s.%s' % (self.visit(node.node), value)
+                    return s
 
         s = '%s[%s]' % (self.visit(node.node), self.visit(node.expr))
         return s


### PR DESCRIPTION
Fixed a bug where object atributes with special characters
(e.g. someObj[':']) would incorrectly have the 
brackets/quotes removed.  See slimit issue #47:
https://github.com/rspivak/slimit/issues/47
(was easier to fix than I thought :+1:).
