### PR TITLE
fixed dot and bracket accessors on immediate numbers

### DIFF
--- a/src/slimit/tests/test_minifier.py
+++ b/src/slimit/tests/test_minifier.py
@@ -398,6 +398,14 @@ class MinifierTestCase(unittest.TestCase):
          """,
          "(function($){$.hello='world';}(jQuery));"),
 
+        # function call on immediate number
+        ('((25)).toString()', '(25).toString();'),
+        ('((25))["toString"]()', '(25).toString();'),
+
+        # attribute access on immediate number
+        ('((25)).attr', '(25).attr;'),
+        ('((25))["attr"]', '(25).attr;'),
+
         # function call in FOR init
         ('for(o(); i < 3; i++) {}', 'for(o();i<3;i++){}'),
 

--- a/src/slimit/visitors/ecmavisitor.py
+++ b/src/slimit/visitors/ecmavisitor.py
@@ -354,7 +354,10 @@ class ECMAVisitor(object):
             template = '(%s.%s)'
         else:
             template = '%s.%s'
-        s = template % (self.visit(node.node), self.visit(node.identifier))
+        left = self.visit(node.node)
+        if isinstance(node.node, ast.Number):
+            left = '(%s)' % left
+        s = template % (left, self.visit(node.identifier))
         return s
 
     def visit_BracketAccessor(self, node):

--- a/src/slimit/visitors/minvisitor.py
+++ b/src/slimit/visitors/minvisitor.py
@@ -388,7 +388,10 @@ class ECMAMinifier(object):
             template = '(%s.%s)'
         else:
             template = '%s.%s'
-        s = template % (self.visit(node.node), self.visit(node.identifier))
+        left = self.visit(node.node)
+        if isinstance(node.node, ast.Number):
+            left = '(%s)' % left
+        s = template % (left, self.visit(node.identifier))
         return s
 
     def visit_BracketAccessor(self, node):
@@ -400,7 +403,10 @@ class ECMAMinifier(object):
             elif value.startswith('"'):
                 value = value.strip('"')
             if _is_identifier(value):
-                s = '%s.%s' % (self.visit(node.node), value)
+                left = self.visit(node.node)
+                if isinstance(node.node, ast.Number):
+                    left = '(%s)' % left
+                s = '%s.%s' % (left, value)
                 return s
 
         s = '%s[%s]' % (self.visit(node.node), self.visit(node.expr))


### PR DESCRIPTION
Please see the unit tests. Without this patch (25).toString() gets compiled to 25.toString() which the browser fails to parse. This patch makes sure we keep the parentheses around numbers.
