### PR TITLE
Allow slimit to work with ply 3.6

### DIFF
--- a/src/slimit/parser.py
+++ b/src/slimit/parser.py
@@ -29,10 +29,10 @@ import ply.yacc
 from slimit import ast
 from slimit.lexer import Lexer
 
-try:
-    from slimit import lextab, yacctab
-except ImportError:
-    lextab, yacctab = 'lextab', 'yacctab'
+# The default values for the `Parser` constructor, passed on to ply; they must
+# be strings
+lextab = '%s.lextab' % __package__
+yacctab = '%s.yacctab' % __package__
 
 
 class Parser(object):


### PR DESCRIPTION
Always set slimit.parser.*tab to strings

These values are expected by ply to be module names, not module
instances. ply 3.6 will crash if actual modules are passed.

Please note that the actual tab modules depend on the version of ply first used. Those modules are checked in, and not modified by this commit.