### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -18,7 +18,7 @@ and runs faster.
 `SlimIt` also provides a library that includes a JavaScript parser,
 lexer, pretty printer and a tree visitor.
 
-`http://slimit.readthedocs.org/ <http://slimit.readthedocs.org/>`_
+`https://slimit.readthedocs.io/ <https://slimit.readthedocs.io/>`_
 
 Installation
 ------------

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ def read(*rel_names):
 setup(
     name='slimit',
     version='0.8.1',
-    url='http://slimit.readthedocs.org',
+    url='https://slimit.readthedocs.io',
     cmdclass = {'build_py': build_py},
     license='MIT',
     description='SlimIt - JavaScript minifier',


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.