### PR TITLE
fix performance problems in the identifier detection

### DIFF
--- a/src/slimit/lexer.py
+++ b/src/slimit/lexer.py
@@ -414,7 +414,7 @@ class Lexer(object):
         r'(?:' + COMBINING_MARK + r'|' + r'[0-9a-zA-Z_$]' + r'|' + DIGIT +
         r'|' + CONNECTOR_PUNCTUATION + r')*'
         )
-    identifier = identifier_start + identifier_part
+    identifier = (identifier_start + identifier_part).replace(']|[', '')
 
     getprop = r'get' + r'(?=\s' + identifier + r')'
     @ply.lex.TOKEN(getprop)


### PR DESCRIPTION
This coalesces alternated character classes into one in `identifier` regex. Speeds up the test case from #77 by factor of **80000**.