### PR TITLE
extended PR #60: fixed dot and bracket accessors on immediate numbers

### DIFF
--- a/src/slimit/tests/test_ecmavisitor.py
+++ b/src/slimit/tests/test_ecmavisitor.py
@@ -500,6 +500,15 @@ class ECMAVisitorTestCase(unittest.TestCase):
           }
         };
         """,
+         # function call on immediate number
+        '(0x25).toString();', 
+        '(1e3).toString();',
+        '(25).toString();',
+
+        # attribute access on immediate number
+        '(25).attr;',
+        '25["attr"];',
+        '0["attr"];',
         ]
 
 

--- a/src/slimit/tests/test_minifier.py
+++ b/src/slimit/tests/test_minifier.py
@@ -399,12 +399,15 @@ class MinifierTestCase(unittest.TestCase):
          "(function($){$.hello='world';}(jQuery));"),
 
         # function call on immediate number
+        ('(0x25).toString()', '0x25.toString();'),
+        ('(1e3).toString()', '1e3.toString();'),
         ('((25)).toString()', '(25).toString();'),
         ('((25))["toString"]()', '(25).toString();'),
 
         # attribute access on immediate number
         ('((25)).attr', '(25).attr;'),
         ('((25))["attr"]', '(25).attr;'),
+        ('((0))["attr"]', '(0).attr;'),
 
         # function call in FOR init
         ('for(o(); i < 3; i++) {}', 'for(o();i<3;i++){}'),

--- a/src/slimit/tests/test_minifier.py
+++ b/src/slimit/tests/test_minifier.py
@@ -398,6 +398,14 @@ class MinifierTestCase(unittest.TestCase):
          """,
          "(function($){$.hello='world';}(jQuery));"),
 
+        # function call on immediate number
+        ('((25)).toString()', '(25).toString();'),
+        ('((25))["toString"]()', '(25).toString();'),
+
+        # attribute access on immediate number
+        ('((25)).attr', '(25).attr;'),
+        ('((25))["attr"]', '(25).attr;'),
+
         # function call in FOR init
         ('for(o(); i < 3; i++) {}', 'for(o();i<3;i++){}'),
 

--- a/src/slimit/visitors/ecmavisitor.py
+++ b/src/slimit/visitors/ecmavisitor.py
@@ -354,7 +354,10 @@ class ECMAVisitor(object):
             template = '(%s.%s)'
         else:
             template = '%s.%s'
-        s = template % (self.visit(node.node), self.visit(node.identifier))
+        left = self.visit(node.node)
+        if isinstance(node.node, ast.Number):
+            left = '(%s)' % left
+        s = template % (left, self.visit(node.identifier))
         return s
 
     def visit_BracketAccessor(self, node):

--- a/src/slimit/visitors/ecmavisitor.py
+++ b/src/slimit/visitors/ecmavisitor.py
@@ -352,12 +352,11 @@ class ECMAVisitor(object):
     def visit_DotAccessor(self, node):
         if getattr(node, '_parens', False):
             template = '(%s.%s)'
+        elif isinstance(node.node, ast.Number):
+            template = '(%s).%s'
         else:
             template = '%s.%s'
-        left = self.visit(node.node)
-        if isinstance(node.node, ast.Number):
-            left = '(%s)' % left
-        s = template % (left, self.visit(node.identifier))
+        s = template % (self.visit(node.node), self.visit(node.identifier))
         return s
 
     def visit_BracketAccessor(self, node):

--- a/src/slimit/visitors/minvisitor.py
+++ b/src/slimit/visitors/minvisitor.py
@@ -388,7 +388,10 @@ class ECMAMinifier(object):
             template = '(%s.%s)'
         else:
             template = '%s.%s'
-        s = template % (self.visit(node.node), self.visit(node.identifier))
+        left = self.visit(node.node)
+        if isinstance(node.node, ast.Number):
+            left = '(%s)' % left
+        s = template % (left, self.visit(node.identifier))
         return s
 
     def visit_BracketAccessor(self, node):
@@ -400,7 +403,10 @@ class ECMAMinifier(object):
             elif value.startswith('"'):
                 value = value.strip('"')
             if _is_identifier(value):
-                s = '%s.%s' % (self.visit(node.node), value)
+                left = self.visit(node.node)
+                if isinstance(node.node, ast.Number):
+                    left = '(%s)' % left
+                s = '%s.%s' % (left, value)
                 return s
 
         s = '%s[%s]' % (self.visit(node.node), self.visit(node.expr))


### PR DESCRIPTION
Run into the same problem as @wkornewald in PR #60 and was able to find some cases, where it is not necessary to put immediate numbers into parenthesis to save a few bytes