### PR TITLE
Remove outdated link to slimit.org

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -13,8 +13,6 @@ and runs faster.
 `SlimIt` also provides a library that includes a JavaScript parser,
 lexer, pretty printer and a tree visitor.
 
-`http://slimit.org/ <http://slimit.org/>`_
-
 Installation
 ------------
 


### PR DESCRIPTION
The domain has expired (it redirects to a page at `buydomains.com`), so it shouldn't be linked from the docs.