### PR TITLE
fixed incorrect children() for ast.NewExpr

### DIFF
--- a/src/slimit/ast.py
+++ b/src/slimit/ast.py
@@ -112,7 +112,7 @@ class NewExpr(Node):
         self.args = [] if args is None else args
 
     def children(self):
-        return [self.identifier, self.args]
+        return [self.identifier] + self.args
 
 class FunctionCall(Node):
     def __init__(self, identifier, args=None):


### PR DESCRIPTION
I've just came across a typo (IMHO) in ast.NewExpr.children():  self.args is a list, so it should be appended to children list